### PR TITLE
Forecast api endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 
 # Ignore application configuration
 /config/application.yml
+
+# Ignore SimpleCov test coverage files
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.4.1'
 gem 'figaro'
 gem 'faraday'
+gem 'fast_jsonapi'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     execjs (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.11.1)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -218,6 +220,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.2)
   faraday
+  fast_jsonapi
   figaro
   jbuilder (~> 2.5)
   launchy

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,0 +1,31 @@
+class Api::V1::ForecastController < ApplicationController
+  def show
+    forecast = Forecast.find_by(city_state: params['location'].downcase)
+
+    unless forecast
+      latitude = google_maps_service.latitude
+      longitude = google_maps_service.longitude
+
+      forecast = Forecast.create(
+        city: google_maps_service.city,
+        state: google_maps_service.state,
+        city_state: google_maps_service.city_state,
+        country: google_maps_service.country,
+        lat: latitude,
+        long: longitude,
+        details: darksky_service(latitude, longitude).details
+      )
+    end
+
+    render json: ForecastSerializer.new(forecast)
+  end
+
+  private
+    def google_maps_service
+      @_google_maps_service ||= GoogleMapsService.new(params['location'])
+    end
+
+    def darksky_service(latitude, longitude)
+      @_dark_sky_service ||= DarkSkyService.new(latitude, longitude)
+    end
+end

--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -1,0 +1,3 @@
+class Forecast < ApplicationRecord
+  
+end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,0 +1,4 @@
+class ForecastSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :updated_at, :city, :state, :country, :details
+end

--- a/app/services/dark_sky_service.rb
+++ b/app/services/dark_sky_service.rb
@@ -1,0 +1,22 @@
+class DarkSkyService
+  attr_reader :latitude, :longitude
+
+  def initialize(latitude, longitude)
+    @latitude = latitude
+    @longitude = longitude
+  end
+
+  def conn
+    @_conn ||= Faraday.new("https://api.darksky.net/forecast/#{ENV['darksky_api_key']}/") do |f|
+      f.adapter Faraday.default_adapter
+    end
+  end
+
+  def response
+    @_response ||= conn.get("#{latitude},#{longitude}")
+  end
+
+  def details
+    JSON.parse(response.body)
+  end
+end

--- a/app/services/google_maps_service.rb
+++ b/app/services/google_maps_service.rb
@@ -1,0 +1,44 @@
+class GoogleMapsService
+  attr_reader :address
+
+  def initialize(address)
+    @address = address
+  end
+
+  def conn
+    @_conn ||= Faraday.new('https://maps.googleapis.com/maps/api/geocode/json') do |f|
+      f.adapter Faraday.default_adapter
+      f.params['key'] = ENV['google_maps_api_key']
+    end
+  end
+
+  def response
+    @_response ||= conn.get do |req|
+      req.params['address'] = address
+    end
+  end
+
+  def latitude
+    JSON.parse(response.body)['results'][0]['geometry']['location']['lat'].to_s
+  end
+
+  def longitude
+    JSON.parse(response.body)['results'][0]['geometry']['location']['lng'].to_s
+  end
+
+  def city
+    address.split(',')[0].capitalize
+  end
+
+  def state
+    address.split(',')[1].upcase
+  end
+
+  def city_state
+    address.downcase
+  end
+
+  def country
+    JSON.parse(response.body)['results'][0]['address_components'].last['long_name']
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get '/forecast', to: 'forecast#show'
+    end
+  end
 end

--- a/db/migrate/20190602194450_create_forecasts.rb
+++ b/db/migrate/20190602194450_create_forecasts.rb
@@ -1,0 +1,15 @@
+class CreateForecasts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :forecasts do |t|
+      t.string :city
+      t.string :state
+      t.string :city_state
+      t.string :country
+      t.string :lat
+      t.string :long
+      t.jsonb :details, null: false, default: '{}'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,30 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_06_02_194450) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "forecasts", force: :cascade do |t|
+    t.string "city"
+    t.string "state"
+    t.string "city_state"
+    t.string "country"
+    t.string "lat"
+    t.string "long"
+    t.jsonb "details", default: "{}", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/requests/api/v1/endpoints/forecast_spec.rb
+++ b/spec/requests/api/v1/endpoints/forecast_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'Forecast API Endpoint' do
+  it 'returns weather data for a city' do
+    query = 'denver,co'
+    get "/api/v1/forecast?location=#{query}"
+
+    expect(response).to be_successful
+
+    json_response = JSON.parse(response.body)
+
+    expect(json_response['data']).to be_present
+    expect(json_response['data']['id']).to be_present
+    expect(json_response['data']['attributes']).to be_present
+    expect(json_response['data']['attributes']['city']).to be_present
+    expect(json_response['data']['attributes']['state']).to be_present
+    expect(json_response['data']['attributes']['country']).to be_present
+    expect(json_response['data']['attributes']['details']).to be_present
+  end
+end

--- a/spec/services/dark_sky_service_spec.rb
+++ b/spec/services/dark_sky_service_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe DarkSkyService, type: :service do
+  before :each do
+    @_service ||= DarkSkyService.new('39.7392358', '-104.990251')
+  end
+
+  describe 'Instance methods' do
+    describe '#details' do
+      it 'returns forecast details for a given location' do
+        expect(@_service.details).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/google_maps_service_spec.rb
+++ b/spec/services/google_maps_service_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe GoogleMapsService, type: :service do
+  before :each do
+    @_service ||= GoogleMapsService.new('denver,co')
+  end
+
+  describe 'Instance methods' do
+    describe '#latitude' do
+      it 'returns the latitude coordinate of the address' do
+        expect(@_service.latitude).to eq('39.7392358')
+      end
+    end
+
+    describe '#longitude' do
+      it 'returns the longitude coordinate of the address' do
+        expect(@_service.longitude).to eq('-104.990251')
+      end
+    end
+
+    describe '#city' do
+      it 'returns the city of the address' do
+        expect(@_service.city).to eq('Denver')
+      end
+    end
+
+    describe '#state' do
+      it 'returns the state of the address' do
+        expect(@_service.state).to eq('CO')
+      end
+    end
+
+    describe '#city_state' do
+      it 'returns the city,state of the address' do
+        expect(@_service.city_state).to eq('denver,co')
+      end
+    end
+
+    describe '#country' do
+      it 'returns the country of the address' do
+        expect(@_service.country).to eq('United States')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds `GET /api/v1/forecast?location=denver,co` endpoint.

Fulfills requirements for:
1. Weather for a City

The functionality for this page should be split into multiple user stories.

```
GET /api/v1/forecast?location=denver,co
Content-Type: application/json
Accept: application/json
```

**Response:**

There is room for personal preference for this response body. Use the mock ups to see what data is required on the front end to decide what you would like to include in your response. If you'd like more of a challenge, you might consider using [Fast JSON API](https://github.com/Netflix/fast_jsonapi) and consider trying to stick to the [JSON 1.0 spec](https://jsonapi.org/).

**Requirements:**

- Needs to pull out the city and state from the GET request and send it to Google's Geocoding API to retrieve the lat and long for the city (this can be its own story). Use of the Google Geocoding API is a hard requirement.
- Retrieve forecast data from the Darksky API using the lat and long

![image](https://user-images.githubusercontent.com/36040194/58768064-469cbb80-8552-11e9-96ab-8c2a30093572.png)