### PR TITLE
Adds Background image for a city endpoint /api/v1/backgrounds?location=

### DIFF
--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::BackgroundsController < ApplicationController
+  def show
+    location = params['location']
+    background_url = flickr_service(location).background_url
+
+    render json: BackgroundSerializer.new(location, background_url).json
+  end
+
+  private
+    def flickr_service(location)
+      @_flickr_service ||= FlickrService.new(location)
+    end
+end

--- a/app/serializers/background_serializer.rb
+++ b/app/serializers/background_serializer.rb
@@ -1,0 +1,17 @@
+class BackgroundSerializer
+  attr_reader :location, :image_url
+
+  def initialize(location, image_url)
+    @location = location
+    @image_url = image_url
+  end
+
+  def json
+    {
+      'data' => {
+        'location' => location,
+        'image_url' => image_url
+      }
+    }
+  end
+end

--- a/app/services/flickr_service.rb
+++ b/app/services/flickr_service.rb
@@ -1,0 +1,26 @@
+class FlickrService
+  attr_reader :location, :filters
+
+  def initialize(location, filters = 'downtown,view')
+    @location = location
+    @filters = filters
+  end
+
+  def conn
+    @_conn ||= Faraday.new('https://www.flickr.com/services/feeds/photos_public.gne') do |f|
+      f.adapter Faraday.default_adapter
+    end
+  end
+
+  def response
+    @_response ||= conn.get do |req|
+      req.params['format'] = 'json'
+      req.params['tags'] = "#{location},#{filters}"
+    end
+  end
+
+  def background_url
+    # Parses out first 15 chars 'jsonFlickrFeed(' and removes trailing ')'
+    JSON.parse(response.body[15..-2])['items'][0]['media']['m']
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/forecast', to: 'forecast#show'
+      get '/backgrounds', to: 'backgrounds#show'
     end
   end
 end

--- a/spec/requests/api/v1/endpoints/backgrounds_spec.rb
+++ b/spec/requests/api/v1/endpoints/backgrounds_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'Backgrounds API endpoint' do
+  it 'returns an image url or the city_state parameter' do
+    query = 'denver,co'
+    get "/api/v1/backgrounds?location=#{query}"
+
+    expect(response).to be_successful
+
+    json_response = JSON.parse(response.body)
+
+    expect(json_response).to be_present
+  end
+end


### PR DESCRIPTION
Adds `GET /api/v1/backgrounds?location=denver,co` endpoint to get a background image based on location parameter.  

Uses free Flickr API endpoint.

Fulfills requirements for:

1. Part Two - Background Image for a City
GET /api/v1/backgrounds?location=denver,co
Content-Type: application/json
Accept: application/json
Response:

This will search the Flickr API or any other images API for images associated with the location. This may not return images as intended, you can feel free to add search terms to your query to the Flickr API such as Parks or nature or skyline or whatever in order to return more appropriate images.