### PR TITLE
Adds nojsoncallback param to Flickr service for json formatting

### DIFF
--- a/app/services/flickr_service.rb
+++ b/app/services/flickr_service.rb
@@ -15,12 +15,12 @@ class FlickrService
   def response
     @_response ||= conn.get do |req|
       req.params['format'] = 'json'
+      req.params['nojsoncallback'] = '1'
       req.params['tags'] = "#{location},#{filters}"
     end
   end
 
   def background_url
-    # Parses out first 15 chars 'jsonFlickrFeed(' and removes trailing ')'
-    JSON.parse(response.body[15..-2])['items'][0]['media']['m']
+    JSON.parse(response.body)['items'][0]['media']['m']
   end
 end


### PR DESCRIPTION
Adds `req.params['nojsoncallback'] = '1'` to Flickr API calls to reformat them into JSON.

Removed un-needed parsing of non-JSON format.