### PR TITLE
Adds edgecase for Forecast to update if older than 2 hours

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::ForecastController < ApplicationController
   def show
     forecast = Forecast.find_by(city_state: params['location'].downcase)
 
-    unless forecast
+    if forecast.nil?
       latitude = google_maps_service.latitude
       longitude = google_maps_service.longitude
 
@@ -15,6 +15,11 @@ class Api::V1::ForecastController < ApplicationController
         long: longitude,
         details: darksky_service(latitude, longitude).details
       )
+    elsif forecast.updated_at < (Time.now - 2.hours.seconds)
+      latitude = forecast.lat
+      longitude = forecast.long
+      forecast.details = darksky_service(latitude, longitude).details
+      forecast.save
     end
 
     render json: ForecastSerializer.new(forecast)

--- a/spec/requests/api/v1/endpoints/forecast_spec.rb
+++ b/spec/requests/api/v1/endpoints/forecast_spec.rb
@@ -17,4 +17,28 @@ describe 'Forecast API Endpoint' do
     expect(json_response['data']['attributes']['country']).to be_present
     expect(json_response['data']['attributes']['details']).to be_present
   end
+
+  it 'updates the Forecast if it has not been updated in one hour' do
+    query = 'denver,co'
+    old_forecast = Forecast.create(
+      city: 'Denver',
+      state: 'CO',
+      city_state: query,
+      country: 'United States',
+      lat: '39.7392358',
+      long: '-104.990251',
+      details: 'Old DarkSky details'
+    )
+
+    two_hours_ago = Time.now - 2.hours.seconds
+    old_forecast.updated_at = two_hours_ago
+    old_forecast.save
+
+    get "/api/v1/forecast?location=#{query}"
+    old_forecast.reload
+
+    expect(Forecast.count).to eq(1)
+    expect(old_forecast.details).to_not eq('Old DarkSky details')
+    expect(old_forecast.updated_at).to_not eq(two_hours_ago)
+  end
 end


### PR DESCRIPTION
Adds feature to Forecast endpoint that it will now update the forecast if it was refreshed greater than 2 hours ago.