### PR TITLE
Users account creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
+    bcrypt (3.1.12)
     bindex (0.7.0)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
@@ -215,6 +216,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   capybara

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    user = User.new(user_params)
+    if user.save
+      api_key = user.create_api_key
+      render json: { api_key: api_key }, status: 201
+    else
+      render json: { error: 'Failed to save new user.' }, status: 400
+    end
+  end
+
+  private
+    def user_params
+      params.permit(:email, :password, :password_confirmation)
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,7 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  def create_api_key
+    self.api_key = SecureRandom.hex
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/forecast', to: 'forecast#show'
       get '/backgrounds', to: 'backgrounds#show'
+      post '/users', to: 'users#create'
     end
   end
 end

--- a/db/migrate/20190603215844_create_users.rb
+++ b/db/migrate/20190603215844_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+      t.string :api_key
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_02_194450) do
+ActiveRecord::Schema.define(version: 2019_06_03_215844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,14 @@ ActiveRecord::Schema.define(version: 2019_06_02_194450) do
     t.string "lat"
     t.string "long"
     t.jsonb "details", default: "{}", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.string "api_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe User, type: :model do
+  context 'Instance methods' do
+    describe '#create_api_key' do
+      subject { User.create(email: 'email', password_digest: 'password') }
+
+      it 'creates an api key on the user' do
+        subject.create_api_key
+
+        expect(subject.api_key).to be_present
+        expect(subject.api_key.length).to eq(32)
+      end
+
+      it 'returns the api_key' do
+        expect(subject.create_api_key.length).to eq(32)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/endpoints/users_spec.rb
+++ b/spec/requests/api/v1/endpoints/users_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'Users API Endpoint' do
+  describe 'POST /api/v1/users' do
+    it 'creates a new user with valid params' do
+      valid_params = {
+                        "email": "whatever@example.com",
+                        "password": "password",
+                        "password_confirmation": "password"
+                      }
+
+      post '/api/v1/users', params: valid_params
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+
+      json_response = JSON.parse(response.body)
+      expect(json_response['api_key']).to be_present
+    end
+
+    it 'errors with invalid params' do
+      invalid_params = {
+                        "email": "whatever@example.com"
+                      }
+
+      post '/api/v1/users', params: invalid_params
+
+      expect(response.status).to eq(400)
+
+      json_response = JSON.parse(response.body)
+      expect(json_response).to eq({ error: 'Failed to save new user.' })
+    end
+  end
+end


### PR DESCRIPTION
Add account creation to fulfill project requirements below:
- Includes migration to create users table
- create_api_key instance method to generate SecureRandom.hex keys.

2. Account Creation
POST /api/v1/users
Content-Type: application/json
Accept: application/json

{
  "email": "whatever@example.com",
  "password": "password"
  "password_confirmation": "password"
}
Response:

status: 201
body:

{
  "api_key": "jgn983hy48thw9begh98h4539h4",
}
