### PR TITLE
4 favoriting locations

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,0 +1,23 @@
+class Api::V1::FavoritesController < ActionController::API
+  def create
+    user = User.find_by(api_key: favorite_params[:api_key])
+
+    if user
+      forecast = Forecast.find_or_create_by_location(favorite_params[:location])
+      new_favorite = user.favorites.create(location: params[:location], forecast_id: forecast.id)
+
+      render json: {
+        location: params[:location],
+        api_key: user.api_key
+      }, status: 201
+
+    else
+      render json: { error: 'Unauthorized' }, status: 401
+    end
+  end
+
+  private
+    def favorite_params
+      params.permit(:location, :api_key)
+    end
+end

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,31 +1,20 @@
 class Api::V1::ForecastController < ApplicationController
   def show
-    forecast = Forecast.find_by(city_state: params['location'].downcase)
+    location = forecast_params[:location].gsub(/\s+/, '').downcase
+    forecast = Forecast.find_or_create_by_location(location)
 
-    if forecast.nil?
-      latitude = google_maps_service.latitude
-      longitude = google_maps_service.longitude
-
-      forecast = Forecast.create(
-        city: google_maps_service.city,
-        state: google_maps_service.state,
-        city_state: google_maps_service.city_state,
-        country: google_maps_service.country,
-        lat: latitude,
-        long: longitude,
-        details: darksky_service(latitude, longitude).details
-      )
-    elsif forecast.updated_at < (Time.now - 2.hours.seconds)
-      latitude = forecast.lat
-      longitude = forecast.long
-      forecast.details = darksky_service(latitude, longitude).details
-      forecast.save
+    if forecast.updated_at < (Time.now - 2.hours.seconds)
+      forecast.update_details
     end
 
     render json: ForecastSerializer.new(forecast)
   end
 
   private
+    def forecast_params
+      params.permit(:location)
+    end
+
     def google_maps_service
       @_google_maps_service ||= GoogleMapsService.new(params['location'])
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::UsersController < ApplicationController
+  protect_from_forgery with: :null_session
+  
   def create
     user = User.new(user_params)
     if user.save

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,4 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :forecast
+end

--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -13,7 +13,6 @@ class Forecast < ApplicationRecord
     longitude = @_google_maps_service.longitude
     @_dark_sky_service ||= DarkSkyService.new(latitude, longitude)
 
-
     Forecast.create(
       city: @_google_maps_service.city,
       state: @_google_maps_service.state,
@@ -23,5 +22,11 @@ class Forecast < ApplicationRecord
       long: longitude,
       details: @_dark_sky_service.details
     )
+  end
+
+  def update_details
+    dark_sky_service ||= DarkSkyService.new(lat, long)
+    self.details = dark_sky_service.details
+    self.save
   end
 end

--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -1,3 +1,27 @@
 class Forecast < ApplicationRecord
-  
+  has_many :favorites
+
+  def self.find_or_create_by_location(location)
+    forecast = Forecast.find_by(city_state: location)
+
+    forecast ? forecast : create_new_forecast(location)
+  end
+
+  def self.create_new_forecast(location)
+    @_google_maps_service ||= GoogleMapsService.new(location)
+    latitude = @_google_maps_service.latitude
+    longitude = @_google_maps_service.longitude
+    @_dark_sky_service ||= DarkSkyService.new(latitude, longitude)
+
+
+    Forecast.create(
+      city: @_google_maps_service.city,
+      state: @_google_maps_service.state,
+      city_state: @_google_maps_service.city_state,
+      country: @_google_maps_service.country,
+      lat: latitude,
+      long: longitude,
+      details: @_dark_sky_service.details
+    )
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :favorites
   has_secure_password
 
   def create_api_key

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       get '/forecast', to: 'forecast#show'
       get '/backgrounds', to: 'backgrounds#show'
       post '/users', to: 'users#create'
+      post '/favorites', to: 'favorites#create'
     end
   end
 end

--- a/db/migrate/20190604015800_create_favorites.rb
+++ b/db/migrate/20190604015800_create_favorites.rb
@@ -1,0 +1,11 @@
+class CreateFavorites < ActiveRecord::Migration[5.2]
+  def change
+    create_table :favorites do |t|
+      t.references :user, foreign_key: true
+      t.references :forecast, foreign_key: true
+      t.string :location
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_215844) do
+ActiveRecord::Schema.define(version: 2019_06_04_015800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "forecast_id"
+    t.string "location"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["forecast_id"], name: "index_favorites_on_forecast_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
 
   create_table "forecasts", force: :cascade do |t|
     t.string "city"
@@ -35,4 +45,6 @@ ActiveRecord::Schema.define(version: 2019_06_03_215844) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "favorites", "forecasts"
+  add_foreign_key "favorites", "users"
 end

--- a/spec/models/forecast_spec.rb
+++ b/spec/models/forecast_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Forecast, type: :model do
+  describe 'Class methods' do
+    describe '::find_or_create_by_location' do
+      it 'creates a forecast if the location does not exist' do
+        expect{Forecast.find_or_create_by_location('Denver,CO')}.to change{Forecast.count}.from(0).to(1)
+      end
+    end
+
+    describe '::create_new_forecast' do
+      it 'creates a new forecast for a city_state' do
+        expect{Forecast.create_new_forecast('Denver,CO')}.to change{Forecast.count}.from(0).to(1)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/endpoints/favorites_spec.rb
+++ b/spec/requests/api/v1/endpoints/favorites_spec.rb
@@ -41,5 +41,3 @@ describe 'Favorites API endpoint' do
     end
   end
 end
-# Remove location blank space
-# a.gsub(/\s+/, '').downcase

--- a/spec/requests/api/v1/endpoints/favorites_spec.rb
+++ b/spec/requests/api/v1/endpoints/favorites_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'Favorites API endpoint' do
+  describe 'POST /api/v1/favorites' do
+    it 'Adds favorite to a user if valid API key' do
+      user = User.create(
+                  email: 'email',
+                  password_digest: 'password',
+                  api_key: 'api_key')
+
+      valid_params = {
+                  "location": "Denver, CO",
+                  "api_key": "api_key"
+                }
+
+      post '/api/v1/favorites', params: valid_params
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+
+      json_response = JSON.parse(response.body)
+
+      expected_response = { 'location' => 'Denver, CO',
+                            'api_key' => 'api_key' }
+      expect(json_response).to eq(expected_response)
+
+      user.reload
+      expect(user.favorites.count).to eq(1)
+    end
+
+    it 'errors with an invalid api_key' do
+      invalid_params = {
+                  "location": "Denver, CO",
+                  "api_key": "invalid_api_key"
+                }
+
+      post '/api/v1/favorites', params: invalid_params
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(401)
+    end
+  end
+end
+# Remove location blank space
+# a.gsub(/\s+/, '').downcase


### PR DESCRIPTION
Adds route for users to add favorites to their account.

`POST /api/v1/favorites`

Fulfills requirements for: 

4. Favoriting Locations
POST /api/v1/favorites
Content-Type: application/json
Accept: application/json

body:

{
  "location": "Denver, CO", # If you decide to store cities in your database you can send an id if you prefer
  "api_key": "jgn983hy48thw9begh98h4539h4"
}
Requirements:

API key must be sent
If no API key or an incorrect key is provided return 401 (Unauthorized)