### PR TITLE
Adds account login with POST /api/v1/sessions

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::SessionsController < ActionController::API
+  def create
+    user = User.find_by(email: user_params[:email])
+
+    if user && user.authenticate(user_params[:password])
+      render json: { api_key: user.api_key }, status: 200
+    else
+      render json: { error: 'Unauthorized' }, status: 401
+    end
+  end
+
+  private
+    def user_params
+      params.permit(:email, :password)
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get '/backgrounds', to: 'backgrounds#show'
       post '/users', to: 'users#create'
       post '/favorites', to: 'favorites#create'
+      post '/sessions', to: 'sessions#create'
     end
   end
 end

--- a/spec/requests/api/v1/endpoints/sessions_spec.rb
+++ b/spec/requests/api/v1/endpoints/sessions_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'Sessions API Endpoint' do
+  describe 'POST /api/v1/sessions' do
+    it 'valid login credentials, returns the users API key' do
+    User.create(
+      email: 'whatever@example.com',
+      password: 'password',
+      api_key: 'api_key')
+
+      valid_params = {
+                        "email": "whatever@example.com",
+                        "password": "password",
+                        "password_confirmation": "password"
+                      }
+
+      post '/api/v1/sessions', params: valid_params
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      json_response = JSON.parse(response.body)
+      expect(json_response['api_key']).to eq('api_key')
+    end
+
+    it 'invalid login credentials, returns unathorized' do
+      invalid_params = {
+                        "email": "whatever@example.com",
+                        "password": "invalid_password",
+                        "password_confirmation": "invalid_password"
+                      }
+
+      post '/api/v1/sessions', params: invalid_params
+
+      expect(response.status).to eq(401)
+
+      json_response = JSON.parse(response.body)
+      expect(json_response).to eq({ 'error' => 'Unauthorized' })
+    end
+  end
+end


### PR DESCRIPTION
Adds POST /api/v1/sessions route to allow users to submit their login credentials and if valid, returns their api key.  Invalid credentials returns an unauthorized error.

Fulfills requirements for:
3. Login
POST /api/v1/sessions
Content-Type: application/json
Accept: application/json

{
  "email": "whatever@example.com",
  "password": "password"
}
Response:

status: 200
body:

{
  "api_key": "jgn983hy48thw9begh98h4539h4",
}

![login](https://user-images.githubusercontent.com/36040194/58901020-82a05f80-86bd-11e9-8c91-3d3404172b25.png)

