### PR TITLE
Adds GET /api/v1/favorites to list all favorites for a user by their …

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -16,8 +16,22 @@ class Api::V1::FavoritesController < ActionController::API
     end
   end
 
+  def index
+    user = User.find_by(api_key: api_key_param[:api_key])
+
+    if user
+      render json: FavoritesSerializer.new(user).to_json, status: 200
+    else
+      render json: { error: 'Unauthorized' }, status: 401
+    end
+  end
+
   private
     def favorite_params
       params.permit(:location, :api_key)
+    end
+
+    def api_key_param
+      params.permit(:api_key)
     end
 end

--- a/app/serializers/favorites_serializer.rb
+++ b/app/serializers/favorites_serializer.rb
@@ -1,0 +1,16 @@
+class FavoritesSerializer
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def to_json
+    user.favorites.map do |favorite|
+      {
+        location: favorite.location,
+        current_weather: favorite.forecast.details,
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get '/backgrounds', to: 'backgrounds#show'
       post '/users', to: 'users#create'
       post '/favorites', to: 'favorites#create'
+      get '/favorites', to: 'favorites#index'
       post '/sessions', to: 'sessions#create'
     end
   end

--- a/spec/requests/api/v1/endpoints/favorites_spec.rb
+++ b/spec/requests/api/v1/endpoints/favorites_spec.rb
@@ -40,4 +40,48 @@ describe 'Favorites API endpoint' do
       expect(response.status).to eq(401)
     end
   end
+
+  describe 'GET /api/v1/favorites' do
+    it 'returns weather forecasts for a user favorites' do
+      user = User.create(
+                  email: 'email',
+                  password_digest: 'password',
+                  api_key: 'api_key')
+
+      forecast = Forecast.create(
+        city: 'Denver',
+        state: 'CO',
+        city_state: 'denver,co',
+        country: 'United States',
+        lat: '1',
+        long: '1',
+        details: 'Darksky Details'
+      )
+
+      Favorite.create(user_id: user.id, forecast_id: forecast.id, location: 'denver,co')
+
+      valid_params = { "api_key": "api_key" }
+
+      get '/api/v1/favorites', params: valid_params
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      json_response = JSON.parse(response.body)
+
+      expect(json_response[0]['location']).to be_present
+      expect(json_response[0]['current_weather']).to be_present
+    end
+
+    it 'errors if invalid api key' do
+      invalid_params = {
+                  "api_key": "invalid_api_key"
+                }
+
+      post '/api/v1/sessions', params: invalid_params
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(401)
+    end
+  end
 end


### PR DESCRIPTION
…api token

Adds GET /api/v1/favorites to allow users to get their favorite locations forecasts by sending their api key with the request.

Fulfills requirements for:
5. Listing Favorite Locations
GET /api/v1/favorites
Content-Type: application/json
Accept: application/json

body:

{
  "api_key": "jgn983hy48thw9begh98h4539h4"
}
Requirements:

API key must be sent
If no API key or an incorrect key is provided return 401 (Unauthorized)
Response:

status: 200
body:
[
  {
    "location": "Denver, CO",
    "current_weather": {
      # This can vary but try to keep it consistent with the
      # structure of the response from the /forecast endpoint
    },
    "location": "Golden, CO",
    "current_weather": {
       {...}
    }
  }
]