### PR TITLE
6 removing favorite locations delete favorites

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -26,6 +26,18 @@ class Api::V1::FavoritesController < ActionController::API
     end
   end
 
+  def destroy
+    user = User.find_by(api_key: favorite_params[:api_key])
+    favorite = user.favorites.find_by(location: favorite_params[:location]) if user
+
+    if user && favorite
+      favorite.destroy
+      render json: FavoritesSerializer.new(user).to_json, status: 200
+    else
+      render json: { error: 'Unauthorized' }, status: 401
+    end
+  end
+
   private
     def favorite_params
       params.permit(:location, :api_key)

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -14,12 +14,4 @@ class Api::V1::ForecastController < ApplicationController
     def forecast_params
       params.permit(:location)
     end
-
-    def google_maps_service
-      @_google_maps_service ||= GoogleMapsService.new(params['location'])
-    end
-
-    def darksky_service(latitude, longitude)
-      @_dark_sky_service ||= DarkSkyService.new(latitude, longitude)
-    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       post '/users', to: 'users#create'
       post '/favorites', to: 'favorites#create'
       get '/favorites', to: 'favorites#index'
+      delete '/favorites', to: 'favorites#destroy'
       post '/sessions', to: 'sessions#create'
     end
   end

--- a/spec/requests/api/v1/endpoints/favorites_spec.rb
+++ b/spec/requests/api/v1/endpoints/favorites_spec.rb
@@ -78,8 +78,67 @@ describe 'Favorites API endpoint' do
                   "api_key": "invalid_api_key"
                 }
 
-      post '/api/v1/sessions', params: invalid_params
+      get '/api/v1/favorites', params: invalid_params
 
+      expect(response).to_not be_successful
+      expect(response.status).to eq(401)
+    end
+  end
+
+  describe 'DELETE /api/v1/favorites' do
+    before :each do
+      @user = User.create(
+        email: 'email',
+        password_digest: 'password',
+        api_key: 'api_key')
+
+      forecast = Forecast.create(
+        city: 'Denver',
+        state: 'CO',
+        city_state: 'denver,co',
+        country: 'United States',
+        lat: '1',
+        long: '1',
+        details: 'Darksky Details'
+        )
+
+      Favorite.create(user_id: @user.id, forecast_id: forecast.id, location: 'Denver, CO')
+    end
+
+    it 'Deletes a favorite from a user with a valid api key' do
+      expect(@user.favorites.count).to eq(1)
+
+      valid_params = {
+                  "location": "Denver, CO",
+                  "api_key": "api_key"
+                }
+
+      delete '/api/v1/favorites', params: valid_params
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      expect(@user.favorites.count).to eq(0)
+    end
+
+    it 'errors if invalid api_key' do
+      invalid_api_params = {
+                  "location": "Denver, CO",
+                  "api_key": "invalid_api_key"
+                }
+
+      delete '/api/v1/favorites', params: invalid_api_params
+      expect(response).to_not be_successful
+      expect(response.status).to eq(401)
+    end
+
+    it 'errors if invalid favorite' do
+      invalid_favorite_params = {
+                  "location": "Invalid favorite",
+                  "api_key": "api_key"
+                }
+
+      delete '/api/v1/favorites', params: invalid_favorite_params
       expect(response).to_not be_successful
       expect(response.status).to eq(401)
     end


### PR DESCRIPTION
Adds `DELETE /api/v1/favorites` for Removing Favorite Locations for a user.
Also removed unused services from the ForecastController since they have moved to the Forecast model now.

Fulfills requirements for:
6. Removing Favorite Locations
DELETE /api/v1/favorites
Content-Type: application/json
Accept: application/json

body:

{
  "location": "Denver, CO", # If you decide to store cities in your database you can send an id if you prefer
  "api_key": "jgn983hy48thw9begh98h4539h4"
}
Requirements:

API key must be sent
If no API key or an incorrect key is provided return 401 (Unauthorized)